### PR TITLE
Fix usbi backend access

### DIFF
--- a/libusb/core.c
+++ b/libusb/core.c
@@ -1287,7 +1287,7 @@ int API_EXPORTED libusb_open_fd(libusb_device *dev,
 {
 	struct libusb_context *ctx = DEVICE_CTX(dev);
 	struct libusb_device_handle *_dev_handle;
-	size_t priv_size = usbi_backend->device_handle_priv_size;
+	size_t priv_size = usbi_backend.device_handle_priv_size;
 	int r;
 	usbi_dbg("open %d.%d", dev->bus_number, dev->device_address);
 
@@ -1310,7 +1310,7 @@ int API_EXPORTED libusb_open_fd(libusb_device *dev,
 	_dev_handle->claimed_interfaces = 0;
 	memset(&_dev_handle->os_priv, 0, priv_size);
 
-	r = usbi_backend->open_fd(_dev_handle, fd);
+	r = usbi_backend.open_fd(_dev_handle, fd);
 	if (r < 0) {
 		usbi_dbg("open %d.%d returns %d", dev->bus_number, dev->device_address, r);
 		libusb_unref_device(dev);


### PR DESCRIPTION
We're using `qmake` as our base branch I suppose. This is a cherry-pick to restore the history of `qmake` (merge commit was lost). Preparation for modifying the bazel build file for linux.