### PR TITLE
Local genrule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -40,6 +40,7 @@ genrule(
     ],
     outs = ["config.h"],
     cmd = "$(location :bootstrap) $< $@",
+    local = True,
 )
 
 cc_library(


### PR DESCRIPTION
Disables remote execution since the configure rule has a lot more outputs than it declares, which fails when we try to go back to local execution after pulling from the remote cache on a build agent.

>[32m[588 / 695][0m 6 / 15 tests;[0m Executing genrule //Modules/BNI.Usb/3rdParty/libusb:config_hdr; 15s local ... (2 actions running)
[31m[1mERROR: [0m/var/lib/buildkite-agent/builds/vanilla.butterflynetinc.com/butterfly-network/software/host/Modules/BNI.Usb/3rdParty/libusb/BUILD:20:1: Executing genrule //Modules/BNI.Usb/3rdParty/libusb:config_hdr failed (Exit 1)
./configure: line 4139: sub/conftest.c: No such file or directory
[32mINFO: [0mElapsed time: 23.923s, Critical Path: 16.08s
[31m[1mFAILED:[0m Build did NOT complete successfully

Will rebase out https://github.com/ButterflyNetwork/libusb/pull/2. 