### PR TITLE
Specify minimum compatibility version for macOS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -45,6 +45,7 @@ cc_library(
     ] + select({
         ":darwin": [
             "-I" + PACKAGE_NAME + "/Xcode",
+            "-mmacosx-version-min=10.12",
         ],
         ":linux": [
             "-I" + PACKAGE_NAME + "/linux",


### PR DESCRIPTION
https://app.asana.com/0/481808206461855/481808206461872

To fix the version-traveling binaries / linker warnings when bazel caching (cross-agent) is enabled.